### PR TITLE
chore: upgrade npm-check-updates to version 22.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mojaloop/license-scanner-tool": "^1.1.1",
         "audit-ci": "^7.1.0",
         "jest": "^30.4.2",
-        "npm-check-updates": "22.2.7",
+        "npm-check-updates": "22.2.9",
         "nyc": "18.0.0",
         "pre-commit": "2.0.0",
         "proxyquire": "2.1.3",
@@ -1664,9 +1664,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,9 +1678,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,9 +1692,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1715,9 +1706,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1732,9 +1720,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1749,9 +1734,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1766,9 +1748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1783,9 +1762,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1800,9 +1776,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1817,9 +1790,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8003,9 +7973,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "22.2.7",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.7.tgz",
-      "integrity": "sha512-Pzs/lTswEe23hT8JUXABl4vgrr0WRKOhw55wAldwngUflk8CwP+grXJt00yGjYiZf2wD1HIfdPa3xaOi1RCyZQ==",
+      "version": "22.2.9",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.9.tgz",
+      "integrity": "sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@mojaloop/license-scanner-tool": "^1.1.1",
     "audit-ci": "^7.1.0",
     "jest": "^30.4.2",
-    "npm-check-updates": "22.2.7",
+    "npm-check-updates": "22.2.9",
     "nyc": "18.0.0",
     "pre-commit": "2.0.0",
     "proxyquire": "2.1.3",


### PR DESCRIPTION
## What
Upgrade `npm-check-updates` from `22.2.7` to `22.2.9` (devDependency).

## Why
Keeps tooling dependency current per PQS maintenance standards. Identified via `npm run dep:check`.

## How to test
```bash
npm install
npm run dep:check   # should report no outdated deps
npm run audit:check # 0 vulnerabilities
npm test            # 151 tests pass
```

## Breaking changes
None.

---

**AI Assistance Disclosure**
AI tools were used in producing part of this contribution.
Tools used: Claude Sonnet 4.6
Scope: PR description draft
All AI-generated content has been reviewed, understood, and validated by the author.